### PR TITLE
fix: update CI token to use RELEASE_PLEASE_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch release-please action token from GITHUB_TOKEN to RELEASE_PLEASE_TOKEN in CI workflow